### PR TITLE
Optimized trail rendering

### DIFF
--- a/platforms/ios/Trails/config.xml
+++ b/platforms/ios/Trails/config.xml
@@ -19,11 +19,11 @@
     <feature name="LocalStorage">
         <param name="ios-package" value="CDVLocalStorage" />
     </feature>
-    <feature name="TestFlightSDK">
-        <param name="ios-package" value="CDVTestFlight" />
-    </feature>
     <feature name="Geolocation">
         <param name="ios-package" value="CDVLocation" />
+    </feature>
+    <feature name="TestFlightSDK">
+        <param name="ios-package" value="CDVTestFlight" />
     </feature>
     <name>Trails</name>
     <description>

--- a/platforms/ios/www/index.html
+++ b/platforms/ios/www/index.html
@@ -264,6 +264,7 @@
     <script type="text/javascript" src="js/application/services.js"></script>
     <script type="text/javascript" src="js/application/directives.js"></script>
     <script type="text/javascript" src="js/application.js"></script>
+    <script type="text/javascript" src="js/application/TrailsCanvasLayer.js"></script>
 
   </body>
 

--- a/platforms/ios/www/js/application/controllers.js
+++ b/platforms/ios/www/js/application/controllers.js
@@ -141,8 +141,11 @@
       $scope.selectedTrail = null;
       $scope.selectedTrails = [];
       
+      // PERF: This is a bit messy, but we're storing precalculated data
+      // about the trails here to increase render speed.
       var allTrails = [];
       var allTrailInfo = [];
+      // PERF: This gives us rainbow-colored lines for debugging :P
       var colors = [
         "#FF0000",
         "#FF7F00",
@@ -161,8 +164,24 @@
           
           $scope.stewards = Models.Steward.query.all();
           $scope.selectedSteward = Models.Steward.query.first();
-          
+
+          // PERF: managing the SVG is a little slow, so instead we're
+          // going to do some precalculation and canvas rendering.
+          // The line below is what we *used* to do.
           // Models.Trail.query.each(renderTrailLayer);
+          
+          // PERF: instead of adding each layer to the map...
+          // we precalculate some data about each trail:
+          // 1. a layer for getting coordinates; ultimately we probably don't
+          //    want this -- it's mainly just overhead, but provided some
+          //    conveniences for experimenting.
+          // 2. The bounds of the trail. We use this when determine whether to
+          //    render a trail on a given tile.
+          // 3. Color. Just for debugging so I could see what's happening.
+          //    This should be removed.
+          // FIXME: this precalculation takes a long time and should really
+          // be done async in a worker. (Check out the timings that get
+          // logged to see how slow. We're talking several seconds.)
           allTrails = Models.Trail.query.all();
           var start = Date.now();
           allTrailInfo = allTrails.map(function(trail) {
@@ -178,6 +197,7 @@
             };
           });
           console.log('Calculating bounds and layers:', Date.now() - start);
+          // PERF: Now create a canvas layer. We'll render each trail in it.
           var canvasTiles = L.tileLayer.canvas();
           canvasTiles.drawTile = renderTrailTile;
           Map.delegate.addLayer(canvasTiles);
@@ -189,44 +209,63 @@
         }
       }
       
+      // PERF: get and cache the device resolution for sharp drawing.
       var displayRatio = window.devicePixelRatio || 1;
+      // PERF: renderTrailTile will actually render trails onto a canvas.
+      // This method is called by Leaflet each time it needs a new tile.
       function renderTrailTile(canvas, tilePoint, zoom) {
         var start = Date.now();
+        
+        // Calculate the pixel coordinates of the tile and the geographic
+        // bounds of the tile. We use these to determine which trails overlap
+        // this tile and should be drawn.
+        var tileX = 256 * tilePoint.x;
+        var tileY = 256 * tilePoint.y;
+        var tileGeoBounds = new L.LatLngBounds(
+          Map.delegate.unproject(L.point(256 * (tilePoint.x - 0.25), 256 * (tilePoint.y + 1.25)), zoom),
+          Map.delegate.unproject(L.point(256 * (tilePoint.x + 1.25), 256 * (tilePoint.y - 0.25)), zoom)
+        );
+        
+        var ctx = canvas.getContext('2d');
+        
+        // Scale the canvas is we're on a retina or hi-res display
         if (displayRatio !== 1) {
           canvas.width = 256 * displayRatio;
           canvas.height = 256 * displayRatio;
           canvas.style.width = "256px";
           canvas.style.height = "256px";
+          ctx.scale(displayRatio, displayRatio);
         }
         
-        var tileX = 256 * tilePoint.x;
-        var tileY = 256 * tilePoint.y;
-        var tileGeo = new L.LatLngBounds(
-          Map.delegate.unproject(L.point(256 * (tilePoint.x - 0.25), 256 * (tilePoint.y + 1.25)), zoom),
-          Map.delegate.unproject(L.point(256 * (tilePoint.x + 1.25), 256 * (tilePoint.y - 0.25)), zoom)
-        );
-        // console.log("Rendering", tilePoint, zoom);
-        
-        var ctx = canvas.getContext('2d');
-        ctx.scale(displayRatio, displayRatio);
+        // Set drawing styles
         ctx.fillStyle = "#f00";
         ctx.lineWidth = 5;
         ctx.strokeStyle = "#00f";
         ctx.lineJoin = "round";
         
         allTrailInfo.forEach(function(info) {
-          if (info.bounds.intersects(tileGeo)) {
-            // setTimeout(function() {
-            // console.log("  + Should render trail", info.trail.get("name"), info.trail);
+          // Only draw the trail if it overlaps with the tile's bounds.
+          if (info.bounds.intersects(tileGeoBounds)) {
             info.layer.eachLayer(function(geoLayer) {
               ctx.strokeStyle = info.color;
-              // FIXME: not always going to have this format for getLatLngs()
+              // FIXME: we know getLatLngs() will always give us back an
+              // array of lines (because all trails are polylines) right now,
+              // but we can't guarantee in the future that that all trails
+              // are polylines. We need to handle different line types.
               var lines = geoLayer.getLatLngs();
               for (var j = 0, lenj = lines.length; j < lenj; j++) {
                 var coordinates = lines[j];
                 ctx.beginPath();
                 for (var i = 0, len = coordinates.length; i < len; i++) {
+                  // NOTE: this projection is expensive. We might be able to
+                  // make it feel faster by doing the projection in a worker
+                  // so it's not blocking user interaction.
                   var pixel = Map.delegate.project(coordinates[i], zoom);
+                  // NOTE: we need to subtract tileX since leaflet's projected
+                  // coordinates are in the space of the whole map (i.e.
+                  // starting at the int'l date line), not just the tile.
+                  // We might be able to remove this math by doing:
+                  //     `ctx.translate(tileX, tileY)`
                   if (i === 0) {
                     ctx.moveTo(pixel.x - tileX, pixel.y - tileY);
                   }
@@ -243,17 +282,12 @@
         });
         
         console.log("  Rendered tile in ", Date.now() - start);
-        // this.tileDrawn(canvas);
         
-        
-        
-        
+        // For debugging, draw a nice little red dot at the tile's center.
         ctx.beginPath();
         ctx.arc(128, 128, 10, 0, 2 * Math.PI, true);
         ctx.closePath();
         ctx.fill();
-        
-        // draw something on the tile canvas
       }
 
       var mapBounds;

--- a/platforms/ios/www/js/application/controllers.js
+++ b/platforms/ios/www/js/application/controllers.js
@@ -268,19 +268,21 @@
       });
 
       $scope.$watch('selectedTrail', function (value) {
+        var fitOptions = {
+          paddingBottomRight: [0, 250]
+        };
+        
         if (trailsLayer) {
           trailsLayer.highlight(value);
           if (trailsLayer.highlighted) {
-            Map.fitBounds(trailsLayer.highlighted.bounds, {
-              paddingBottomRight: [0, 250]
-            });
+            Map.fitBounds(trailsLayer.highlighted.bounds, fitOptions);
           }
         }
         
         ng.forEach(trailLayers, function (layer) {
           if (layer.get('record') === value)  {
             selectTrailLayer(layer);
-            Map.fitBounds( layer.getBounds() );
+            Map.fitBounds( layer.getBounds(), fitOptions );
           } else {
             deselectTrailLayer(layer);
           }

--- a/platforms/ios/www/js/application/services.js
+++ b/platforms/ios/www/js/application/services.js
@@ -870,8 +870,8 @@
       return this;
     },
 
-    fitBounds: function (bounds) {
-      this.delegate.fitBounds(bounds);
+    fitBounds: function (bounds, options) {
+      this.delegate.fitBounds(bounds, options);
       return this;
     }
 
@@ -1164,12 +1164,11 @@
           color: "#a3a3a3",
           opacity: 0.5
         },
-        // PERF: this is likely neither right, nor the right place to do this
-        // Simplifying the lines makes a *BIG* difference for performance in
-        // both SVG (GeoJSON layer) rendering and canvas rendering. Ideally
-        // we'd have a low detail and high detail version of each trail for
-        // differing zoom levels.
-        smoothFactor: 100
+        highlightStyle: {
+          color: "#333333",
+          opacity: 1
+        },
+        smoothFactor: 2
       },
       record: null
     },
@@ -1177,10 +1176,7 @@
     select: function () {
       this.selected = true;
 
-      this.delegate.setStyle({
-        opacity: 1,
-        color: "#333333"
-      });
+      this.delegate.setStyle(this.get('options').highlightStyle);
 
       this.bringToFront();
 
@@ -1190,10 +1186,7 @@
     deselect: function () {
       this.selected = false;
 
-      this.delegate.setStyle({
-        opacity: 0.5,
-        color: "#a3a3a3"
-      });
+      this.delegate.setStyle(this.get('options').style);
 
       this.bringToBack();
 

--- a/platforms/ios/www/js/application/services.js
+++ b/platforms/ios/www/js/application/services.js
@@ -429,7 +429,9 @@
 
       if (data.trails) {
         ng.forEach(data.trails, function (trail) {
-          results.push( new Trail(trail) );
+          if (trail.segmentIds.length) {
+            results.push( new Trail(trail) );
+          }
         });
       }
 
@@ -929,7 +931,7 @@
   var TILE_LAYERS = {
     "terrain": {
       name: "Terrain",
-      url: "tiles/terrain/{z}/{x}/{y}.jpg"
+      url: "http://{s}.tiles.mapbox.com/v3/codeforamerica.map-j35lxf9d/{z}/{x}/{y}.png"
     },
     "satellite": {
       name: "Satellite",
@@ -1148,7 +1150,8 @@
         style: {
           color: "#a3a3a3",
           opacity: 0.5
-        }
+        },
+        smoothFactor: 100
       },
       record: null
     },

--- a/platforms/ios/www/js/application/services.js
+++ b/platforms/ios/www/js/application/services.js
@@ -1151,6 +1151,11 @@
           color: "#a3a3a3",
           opacity: 0.5
         },
+        // PERF: this is likely neither right, nor the right place to do this
+        // Simplifying the lines makes a *BIG* difference for performance in
+        // both SVG (GeoJSON layer) rendering and canvas rendering. Ideally
+        // we'd have a low detail and high detail version of each trail for
+        // differing zoom levels.
         smoothFactor: 100
       },
       record: null

--- a/plugins/ios.json
+++ b/plugins/ios.json
@@ -1,1 +1,45 @@
-{"prepare_queue":{"installed":[],"uninstalled":[]},"config_munge":{"config.xml":{"/*":{"<feature name=\"Geolocation\"><param name=\"ios-package\" value=\"CDVLocation\" /></feature>":1},"/widget":{"<feature name=\"TestFlightSDK\"><param name=\"ios-package\" value=\"CDVTestFlight\" /></feature>":1}},"framework":{"libz.dylib":{"false":1}}},"installed_plugins":{"org.apache.cordova.geolocation":{"PACKAGE_NAME":"org.codeforamerica.trails"},"com.testflightapp.cordova-plugin":{"PACKAGE_NAME":"org.codeforamerica.trails"}},"dependent_plugins":{}}
+{
+    "prepare_queue": {
+        "installed": [],
+        "uninstalled": []
+    },
+    "config_munge": {
+        "files": {
+            "config.xml": {
+                "parents": {
+                    "/*": [
+                        {
+                            "xml": "<feature name=\"Geolocation\"><param name=\"ios-package\" value=\"CDVLocation\" /></feature>",
+                            "count": 1
+                        }
+                    ],
+                    "/widget": [
+                        {
+                            "xml": "<feature name=\"TestFlightSDK\"><param name=\"ios-package\" value=\"CDVTestFlight\" /></feature>",
+                            "count": 1
+                        }
+                    ]
+                }
+            },
+            "framework": {
+                "parents": {
+                    "libz.dylib": [
+                        {
+                            "xml": "false",
+                            "count": 1
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "installed_plugins": {
+        "org.apache.cordova.geolocation": {
+            "PACKAGE_NAME": "org.codeforamerica.trails"
+        },
+        "com.testflightapp.cordova-plugin": {
+            "PACKAGE_NAME": "org.codeforamerica.trails"
+        }
+    },
+    "dependent_plugins": {}
+}

--- a/www/index.html
+++ b/www/index.html
@@ -264,6 +264,7 @@
     <script type="text/javascript" src="js/application/services.js"></script>
     <script type="text/javascript" src="js/application/directives.js"></script>
     <script type="text/javascript" src="js/application.js"></script>
+    <script type="text/javascript" src="js/application/TrailsCanvasLayer.js"></script>
 
   </body>
 

--- a/www/js/application/TrailsCanvasLayer.js
+++ b/www/js/application/TrailsCanvasLayer.js
@@ -1,0 +1,182 @@
+angular.module('trails.services').factory('TrailsCanvasLayer', [
+  'MapTrailLayer',
+  function(MapTrailLayer) {
+    var pixelRatio = window.devicePixelRatio || 1;
+    
+    /**
+     * TrailsCanvasLayer is a leaflet layer that can render a set of trails
+     * as lines on canvas tiles (instead of as SVG). It also contains several
+     * optimizations to try and make things a bit faster.
+     * 
+     * TODO: This isn't quite there yet, but it would be sweet if the API
+     * here took some cues from LayerGroup -- you could add & remove other
+     * sublayers on this layer.
+     **/
+    var TrailsCanvasLayer = L.TileLayer.Canvas.extend({
+      initialize: function(options) {
+        var self = L.TileLayer.Canvas.prototype.initialize.apply(this, arguments);
+        this.trailLayerModels = options.trails.map(MapTrailLayer.fromTrail);
+        this.trailLayers = this.trailLayerModels.map(function(layer) {
+          return layer.delegate;
+        });
+        this._filter = null;
+        this.highlighted = null;
+        return self;
+      },
+      
+      /**
+       * Limits what trails get drawn. Provide a function that returns
+       * true or false for whether to render a trail.
+       **/
+      filter: function(predicate) {
+        if (predicate != this._filter) {
+          this._filter = predicate;
+          this.redraw();
+        }
+      },
+      
+      /**
+       * Highlight a particular trail (or null for no highlight).
+       * The highlighted trail will be drawn in front of other trails and
+       * with styling from its `highlightStyle` option.
+       **/
+      highlight: function(trail) {
+        if (trail != this.highlighted) {
+          this.highlighted = this.trailLayerModels.filter(function(layer) {
+            return layer.get('record') === trail;
+          })[0];
+          if (this.highlighted) {
+            this.highlighted = this.highlighted.delegate;
+          }
+          this.redraw();
+        }
+      },
+      
+      drawTile: function(canvas, tilePoint, zoom) {
+        var pixelScale = Math.pow(0.5, 15 - zoom);
+        
+        // Calculate the pixel coordinates of the tile and the geographic
+        // bounds of the tile. We use these to determine which trails overlap
+        // this tile and should be drawn.
+        var tileX = 256 * tilePoint.x;
+        var tileY = 256 * tilePoint.y;
+        var tileGeoBounds = new L.LatLngBounds(
+          this._map.unproject(L.point(256 * (tilePoint.x - 0.25), 256 * (tilePoint.y + 1.25)), zoom),
+          this._map.unproject(L.point(256 * (tilePoint.x + 1.25), 256 * (tilePoint.y - 0.25)), zoom)
+        );
+        
+        var ctx = canvas.getContext('2d');
+        
+        // Scale the canvas if we're on a retina or hi-res display
+        if (pixelRatio !== 1) {
+          canvas.width = 256 * pixelRatio;
+          canvas.height = 256 * pixelRatio;
+          canvas.style.width = "256px";
+          canvas.style.height = "256px";
+          ctx.scale(pixelRatio, pixelRatio);
+        }
+        
+        // Set drawing styles
+        ctx.fillStyle = "#f00";
+        ctx.lineWidth = 5;
+        ctx.strokeStyle = "#00f";
+        ctx.lineJoin = "round";
+        ctx.lineCap = "round";
+
+        var highlight = null;
+        ctx.lastStyle = null;
+        this.trailLayers.forEach(function(trailLayer) {
+          if ((this._filter ? this._filter(trailLayer) : true) &&
+              layerBounds(trailLayer).intersects(tileGeoBounds)) {
+            if (trailLayer === this.highlighted) {
+              highlight = trailLayer;
+              return;
+            }
+            
+            this.drawTrail(ctx, pixelScale, tileX, tileY, trailLayer);
+          }
+        }, this);
+        
+        if (highlight) {
+          this.drawTrail(ctx, pixelScale, tileX, tileY, highlight, highlight.options.highlightStyle);
+        }
+      },
+      
+      drawTrail: function(ctx, pixelScale, tileX, tileY, trailLayer, style) {
+        style = style || trailLayer.options.style;
+        
+        // setting context styles turns out to be pretty expensive,
+        // so avoid doing so if there's no change.
+        if (style !== ctx.lastStyle) {
+          ctx.strokeStyle = style.color || "#f00";
+          ctx.globalAlpha = ('opacity' in style) ? style.opacity : 1;
+          ctx.lineWidth = style.weight || 5;
+          ctx.lastStyle = style;
+        }
+        
+        trailLayer.eachLayer(function(geoLayer) {
+          var lines = layerProjection(geoLayer, this._map);
+          for (var j = 0, lenj = lines.length; j < lenj; j++) {
+            var line = lines[j];
+            ctx.beginPath();
+            for (var i = 0, len = line.length; i < len; i++) {
+              var pixel = line[i];
+              if (i === 0) {
+                ctx.moveTo(pixel.x * pixelScale - tileX, pixel.y * pixelScale - tileY);
+              }
+              else {
+                ctx.lineTo(pixel.x * pixelScale - tileX, pixel.y * pixelScale - tileY);
+              }
+            }
+            ctx.stroke();
+            ctx.closePath();
+          }
+        }, this);
+      },
+      
+      onAdd: function(map) {
+        // We don't want to calculate *everything* right away, but after a
+        // quick breather, we will (so future panning is speedy)
+        var self = this;
+        setTimeout(function() {
+          self.trailLayers.forEach(function(layer) {
+            TrailsCanvasLayer.processLayer(layer, map)
+          });
+        }, 2000);
+        
+        return L.TileLayer.Canvas.prototype.onAdd.apply(this, arguments);
+      }
+    });
+    
+    // Internal. Used to lazily retrieve and cache the bounds of a layer.
+    function layerBounds(layer) {
+      if (!layer.bounds) {
+        layer.bounds = layer.getBounds();
+      }
+      return layer.bounds;
+    }
+    
+    // Internal. Used to lazily retrieve and cache the projected, simplified
+    // line coordinates for a layer.
+    function layerProjection(layer, map) {
+      if (!layer.simplified) {
+        layer.simplified = layer.getLatLngs().map(function(line) {
+          return L.LineUtil.simplify(line.map(function(coordinate) {
+            return map.project(coordinate, 15);
+          }), 2);
+        });
+      }
+      return layer.simplified;
+    }
+    
+    // Pre-calculate cached data like bounds and projection for a layer
+    TrailsCanvasLayer.processLayer = function processLayer(layer, map) {
+      layerBounds(layer);
+      layer.eachLayer(function(geoLayer) {
+        layerProjection(geoLayer, map);
+      });
+    };
+    
+    return TrailsCanvasLayer;
+  }
+]);

--- a/www/js/application/controllers.js
+++ b/www/js/application/controllers.js
@@ -141,8 +141,11 @@
       $scope.selectedTrail = null;
       $scope.selectedTrails = [];
       
+      // PERF: This is a bit messy, but we're storing precalculated data
+      // about the trails here to increase render speed.
       var allTrails = [];
       var allTrailInfo = [];
+      // PERF: This gives us rainbow-colored lines for debugging :P
       var colors = [
         "#FF0000",
         "#FF7F00",
@@ -161,8 +164,24 @@
           
           $scope.stewards = Models.Steward.query.all();
           $scope.selectedSteward = Models.Steward.query.first();
-          
+
+          // PERF: managing the SVG is a little slow, so instead we're
+          // going to do some precalculation and canvas rendering.
+          // The line below is what we *used* to do.
           // Models.Trail.query.each(renderTrailLayer);
+          
+          // PERF: instead of adding each layer to the map...
+          // we precalculate some data about each trail:
+          // 1. a layer for getting coordinates; ultimately we probably don't
+          //    want this -- it's mainly just overhead, but provided some
+          //    conveniences for experimenting.
+          // 2. The bounds of the trail. We use this when determine whether to
+          //    render a trail on a given tile.
+          // 3. Color. Just for debugging so I could see what's happening.
+          //    This should be removed.
+          // FIXME: this precalculation takes a long time and should really
+          // be done async in a worker. (Check out the timings that get
+          // logged to see how slow. We're talking several seconds.)
           allTrails = Models.Trail.query.all();
           var start = Date.now();
           allTrailInfo = allTrails.map(function(trail) {
@@ -178,6 +197,7 @@
             };
           });
           console.log('Calculating bounds and layers:', Date.now() - start);
+          // PERF: Now create a canvas layer. We'll render each trail in it.
           var canvasTiles = L.tileLayer.canvas();
           canvasTiles.drawTile = renderTrailTile;
           Map.delegate.addLayer(canvasTiles);
@@ -189,44 +209,63 @@
         }
       }
       
+      // PERF: get and cache the device resolution for sharp drawing.
       var displayRatio = window.devicePixelRatio || 1;
+      // PERF: renderTrailTile will actually render trails onto a canvas.
+      // This method is called by Leaflet each time it needs a new tile.
       function renderTrailTile(canvas, tilePoint, zoom) {
         var start = Date.now();
+        
+        // Calculate the pixel coordinates of the tile and the geographic
+        // bounds of the tile. We use these to determine which trails overlap
+        // this tile and should be drawn.
+        var tileX = 256 * tilePoint.x;
+        var tileY = 256 * tilePoint.y;
+        var tileGeoBounds = new L.LatLngBounds(
+          Map.delegate.unproject(L.point(256 * (tilePoint.x - 0.25), 256 * (tilePoint.y + 1.25)), zoom),
+          Map.delegate.unproject(L.point(256 * (tilePoint.x + 1.25), 256 * (tilePoint.y - 0.25)), zoom)
+        );
+        
+        var ctx = canvas.getContext('2d');
+        
+        // Scale the canvas is we're on a retina or hi-res display
         if (displayRatio !== 1) {
           canvas.width = 256 * displayRatio;
           canvas.height = 256 * displayRatio;
           canvas.style.width = "256px";
           canvas.style.height = "256px";
+          ctx.scale(displayRatio, displayRatio);
         }
         
-        var tileX = 256 * tilePoint.x;
-        var tileY = 256 * tilePoint.y;
-        var tileGeo = new L.LatLngBounds(
-          Map.delegate.unproject(L.point(256 * (tilePoint.x - 0.25), 256 * (tilePoint.y + 1.25)), zoom),
-          Map.delegate.unproject(L.point(256 * (tilePoint.x + 1.25), 256 * (tilePoint.y - 0.25)), zoom)
-        );
-        // console.log("Rendering", tilePoint, zoom);
-        
-        var ctx = canvas.getContext('2d');
-        ctx.scale(displayRatio, displayRatio);
+        // Set drawing styles
         ctx.fillStyle = "#f00";
         ctx.lineWidth = 5;
         ctx.strokeStyle = "#00f";
         ctx.lineJoin = "round";
         
         allTrailInfo.forEach(function(info) {
-          if (info.bounds.intersects(tileGeo)) {
-            // setTimeout(function() {
-            // console.log("  + Should render trail", info.trail.get("name"), info.trail);
+          // Only draw the trail if it overlaps with the tile's bounds.
+          if (info.bounds.intersects(tileGeoBounds)) {
             info.layer.eachLayer(function(geoLayer) {
               ctx.strokeStyle = info.color;
-              // FIXME: not always going to have this format for getLatLngs()
+              // FIXME: we know getLatLngs() will always give us back an
+              // array of lines (because all trails are polylines) right now,
+              // but we can't guarantee in the future that that all trails
+              // are polylines. We need to handle different line types.
               var lines = geoLayer.getLatLngs();
               for (var j = 0, lenj = lines.length; j < lenj; j++) {
                 var coordinates = lines[j];
                 ctx.beginPath();
                 for (var i = 0, len = coordinates.length; i < len; i++) {
+                  // NOTE: this projection is expensive. We might be able to
+                  // make it feel faster by doing the projection in a worker
+                  // so it's not blocking user interaction.
                   var pixel = Map.delegate.project(coordinates[i], zoom);
+                  // NOTE: we need to subtract tileX since leaflet's projected
+                  // coordinates are in the space of the whole map (i.e.
+                  // starting at the int'l date line), not just the tile.
+                  // We might be able to remove this math by doing:
+                  //     `ctx.translate(tileX, tileY)`
                   if (i === 0) {
                     ctx.moveTo(pixel.x - tileX, pixel.y - tileY);
                   }
@@ -243,17 +282,12 @@
         });
         
         console.log("  Rendered tile in ", Date.now() - start);
-        // this.tileDrawn(canvas);
         
-        
-        
-        
+        // For debugging, draw a nice little red dot at the tile's center.
         ctx.beginPath();
         ctx.arc(128, 128, 10, 0, 2 * Math.PI, true);
         ctx.closePath();
         ctx.fill();
-        
-        // draw something on the tile canvas
       }
 
       var mapBounds;

--- a/www/js/application/controllers.js
+++ b/www/js/application/controllers.js
@@ -268,19 +268,21 @@
       });
 
       $scope.$watch('selectedTrail', function (value) {
+        var fitOptions = {
+          paddingBottomRight: [0, 250]
+        };
+        
         if (trailsLayer) {
           trailsLayer.highlight(value);
           if (trailsLayer.highlighted) {
-            Map.fitBounds(trailsLayer.highlighted.bounds, {
-              paddingBottomRight: [0, 250]
-            });
+            Map.fitBounds(trailsLayer.highlighted.bounds, fitOptions);
           }
         }
         
         ng.forEach(trailLayers, function (layer) {
           if (layer.get('record') === value)  {
             selectTrailLayer(layer);
-            Map.fitBounds( layer.getBounds() );
+            Map.fitBounds( layer.getBounds(), fitOptions );
           } else {
             deselectTrailLayer(layer);
           }

--- a/www/js/application/services.js
+++ b/www/js/application/services.js
@@ -931,7 +931,7 @@
   var TILE_LAYERS = {
     "terrain": {
       name: "Terrain",
-      url: "tiles/terrain/{z}/{x}/{y}.jpg"
+      url: "http://{s}.tiles.mapbox.com/v3/codeforamerica.map-j35lxf9d/{z}/{x}/{y}.png"
     },
     "satellite": {
       name: "Satellite",

--- a/www/js/application/services.js
+++ b/www/js/application/services.js
@@ -870,8 +870,8 @@
       return this;
     },
 
-    fitBounds: function (bounds) {
-      this.delegate.fitBounds(bounds);
+    fitBounds: function (bounds, options) {
+      this.delegate.fitBounds(bounds, options);
       return this;
     }
 
@@ -1164,12 +1164,11 @@
           color: "#a3a3a3",
           opacity: 0.5
         },
-        // PERF: this is likely neither right, nor the right place to do this
-        // Simplifying the lines makes a *BIG* difference for performance in
-        // both SVG (GeoJSON layer) rendering and canvas rendering. Ideally
-        // we'd have a low detail and high detail version of each trail for
-        // differing zoom levels.
-        smoothFactor: 100
+        highlightStyle: {
+          color: "#333333",
+          opacity: 1
+        },
+        smoothFactor: 2
       },
       record: null
     },
@@ -1177,10 +1176,7 @@
     select: function () {
       this.selected = true;
 
-      this.delegate.setStyle({
-        opacity: 1,
-        color: "#333333"
-      });
+      this.delegate.setStyle(this.get('options').highlightStyle);
 
       this.bringToFront();
 
@@ -1190,10 +1186,7 @@
     deselect: function () {
       this.selected = false;
 
-      this.delegate.setStyle({
-        opacity: 0.5,
-        color: "#a3a3a3"
-      });
+      this.delegate.setStyle(this.get('options').style);
 
       this.bringToBack();
 

--- a/www/js/application/services.js
+++ b/www/js/application/services.js
@@ -429,7 +429,9 @@
 
       if (data.trails) {
         ng.forEach(data.trails, function (trail) {
-          results.push( new Trail(trail) );
+          if (trail.segmentIds.length) {
+            results.push( new Trail(trail) );
+          }
         });
       }
 
@@ -1148,7 +1150,8 @@
         style: {
           color: "#a3a3a3",
           opacity: 0.5
-        }
+        },
+        smoothFactor: 100
       },
       record: null
     },

--- a/www/js/application/services.js
+++ b/www/js/application/services.js
@@ -1151,6 +1151,11 @@
           color: "#a3a3a3",
           opacity: 0.5
         },
+        // PERF: this is likely neither right, nor the right place to do this
+        // Simplifying the lines makes a *BIG* difference for performance in
+        // both SVG (GeoJSON layer) rendering and canvas rendering. Ideally
+        // we'd have a low detail and high detail version of each trail for
+        // differing zoom levels.
         smoothFactor: 100
       },
       record: null

--- a/www/tiles/terrain
+++ b/www/tiles/terrain
@@ -1,1 +1,0 @@
-/Users/ryan/Code/tile-utils/tmp


### PR DESCRIPTION
This is just a start at solving the problem. Basically, there are 3 (and a half?) big things we're doing here:
1. We straight up don't load trails that don't have any segments. These are basically just bad data and we should never deal with them when iterating over trails.
2. Simplifying (smoothing) the trail lines. This makes a _big_ impact no matter what rendering method we use. Some of these trail lines are crazy complex.
3. Rendering the trails to a canvas instead of letting leaflet do SVG. This seems to be much nicer on the browser. Additionally, rendering is done less often (since we aren't moving SVG DOM elements all over the place; we're just drawing an image and moving it).

3.5. Precalculating layer/bounds information so we don't have to do it every time we try and render a trail.

Notes:
- We could also use `L_PREFER_CANVAS = true` to make leaflet do the canvas rendering. However, this would cause _all_ layers to use canvas and is also likely not quite as fast as some of the hand optimizations we could do (and area already doing—see bounds caching above).
- If we really don't want to do canvas rendering, adding `pointerEvents: "none"` to the layer options seems to give a small speed boost to SVG rendering.
- All the bounds precalculation should really be done in a worker so as not to block UI interaction.
- We could probably do all trail projection in a worker as well. This is almost certainly the most expensive part of rendering a trail. There's probably relevant code to steal from either Leaflet or NodeTiles.
- We could cache projections for a given zoom level.
- We could cache tiles. `L.TileLayer` has a `reuseTiles` option which might do this for us. If we do so, we should also see if there's a way to capture iOS's `UIApplicationDidReceiveMemoryWarningNotification` and trigger an event in JS so we can purge the cache. More info here: [https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intfm/UIApplicationDelegate/applicationDidReceiveMemoryWarning:](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intfm/UIApplicationDelegate/applicationDidReceiveMemoryWarning:) and here: [https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplication_Class/Reference/Reference.html#//apple_ref/c/data/UIApplicationDidReceiveMemoryWarningNotification](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplication_Class/Reference/Reference.html#//apple_ref/c/data/UIApplicationDidReceiveMemoryWarningNotification)
- Obviously, the rainbow rendering needs to go and the styles should be tweaked/loaded from somewhere else.
- The render method needs to have other ways of filtering trails (e.g. only render trails of a certain type, highlight the current trail, etc.).
- The line simplification/smoothing should _probably_ happen somewhere other than where it is now. It's probably also not quite the _right amount_ of smoothing. Haven't looked into very many different values yet.
  1. It would be best if it were precalculated in the data on compilation and not done at run-time.
  2. It would be great to have a low-detail, smoothed version and a hi-detail, un-smoothed version of each trail line that we could switch between at different zoom levels.
