### PR TITLE
Smooth animations and no flashes for trails view

### DIFF
--- a/platforms/ios/www/js/application/controllers.js
+++ b/platforms/ios/www/js/application/controllers.js
@@ -351,7 +351,7 @@
               viewportHeight = window.innerHeight,
               initialOffset = viewportHeight - footerHeight - trailNavHeight - attributesHeight;
 
-              trailView.style.top = initialOffset + 'px';
+              trailView.style.webkitTransform = 'translate3d(0, ' + initialOffset + 'px, 0)';
       };
 
 

--- a/platforms/ios/www/js/application/controllers.js
+++ b/platforms/ios/www/js/application/controllers.js
@@ -43,6 +43,20 @@
       }
 
       $scope.showView = showView;
+      
+      // prevent scrolling when not in fullscreen mode
+      document.getElementsByClassName('trail-and-trailhead-data')[0].addEventListener('touchmove', function (event) {
+        if (!$scope.fullscreen) {
+          event.preventDefault();
+        }
+      });
+      
+      // when leaving fullscreen mode, make sure we scroll back to the top
+      $scope.$watch('fullscreen', function(value) {
+        if (!value) {
+          document.getElementsByClassName('trail-and-trailhead-data')[0].scrollTop = 0;
+        }
+      })
 
       //
       // MAP LOGIC

--- a/platforms/ios/www/less/application.less
+++ b/platforms/ios/www/less/application.less
@@ -397,16 +397,17 @@ body {
 #trail-view {
 
   &.fullscreen {
-    top: 0px !important; 
+    -webkit-transform: translate3d(0, 0, 0) !important;
     .trail-and-trailhead-data {
-      overflow: scroll; 
+      overflow: scroll;
       -webkit-overflow-scrolling: touch;
     }
   }
 
-  .transition(top 0.5s);
+  .transition(-webkit-transform 0.5s);
 
-  transform: translate3d(0px, 0px, 0);
+  -webkit-transform: translate3d(0, 20px, 0); /* Footer Height, Flush */
+  transform: translate3d(0px, 20px, 0);
   position: fixed;
   background-color: @white-color;
   width: 100%;
@@ -414,7 +415,7 @@ body {
   max-height: @device-height;
   background-color: @white-color;
   z-index: @z-index-4;
-  top: 20px; /* Footer Height, Flush */
+  top: 0;
   .trail-nav {
     display: inline-block;
     position: relative;

--- a/platforms/ios/www/less/application.less
+++ b/platforms/ios/www/less/application.less
@@ -398,10 +398,10 @@ body {
 
   &.fullscreen {
     -webkit-transform: translate3d(0, 0, 0) !important;
-    .trail-and-trailhead-data {
-      overflow: scroll;
-      -webkit-overflow-scrolling: touch;
-    }
+    // .trail-and-trailhead-data {
+    //   overflow: auto;
+    //   -webkit-overflow-scrolling: touch;
+    // }
   }
 
   .transition(-webkit-transform 0.5s);
@@ -546,6 +546,9 @@ body {
     width: 100%;
     /* ^^ Should this be a device width var? */
     background-color: @white-color;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    -webkit-transform: translate3d(0, 0, 0);
     .trail-data {
       display: inline-block;
       position: relative;

--- a/www/js/application/controllers.js
+++ b/www/js/application/controllers.js
@@ -351,7 +351,7 @@
               viewportHeight = window.innerHeight,
               initialOffset = viewportHeight - footerHeight - trailNavHeight - attributesHeight;
 
-              trailView.style.top = initialOffset + 'px';
+              trailView.style.webkitTransform = 'translate3d(0, ' + initialOffset + 'px, 0)';
       };
 
 

--- a/www/js/application/controllers.js
+++ b/www/js/application/controllers.js
@@ -43,6 +43,20 @@
       }
 
       $scope.showView = showView;
+      
+      // prevent scrolling when not in fullscreen mode
+      document.getElementsByClassName('trail-and-trailhead-data')[0].addEventListener('touchmove', function (event) {
+        if (!$scope.fullscreen) {
+          event.preventDefault();
+        }
+      });
+      
+      // when leaving fullscreen mode, make sure we scroll back to the top
+      $scope.$watch('fullscreen', function(value) {
+        if (!value) {
+          document.getElementsByClassName('trail-and-trailhead-data')[0].scrollTop = 0;
+        }
+      })
 
       //
       // MAP LOGIC

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -397,16 +397,17 @@ body {
 #trail-view {
 
   &.fullscreen {
-    top: 0px !important; 
+    -webkit-transform: translate3d(0, 0, 0) !important;
     .trail-and-trailhead-data {
-      overflow: scroll; 
+      overflow: scroll;
       -webkit-overflow-scrolling: touch;
     }
   }
 
-  .transition(top 0.5s);
+  .transition(-webkit-transform 0.5s);
 
-  transform: translate3d(0px, 0px, 0);
+  -webkit-transform: translate3d(0, 20px, 0); /* Footer Height, Flush */
+  transform: translate3d(0px, 20px, 0);
   position: fixed;
   background-color: @white-color;
   width: 100%;
@@ -414,7 +415,7 @@ body {
   max-height: @device-height;
   background-color: @white-color;
   z-index: @z-index-4;
-  top: 20px; /* Footer Height, Flush */
+  top: 0;
   .trail-nav {
     display: inline-block;
     position: relative;

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -398,10 +398,10 @@ body {
 
   &.fullscreen {
     -webkit-transform: translate3d(0, 0, 0) !important;
-    .trail-and-trailhead-data {
-      overflow: scroll;
-      -webkit-overflow-scrolling: touch;
-    }
+    // .trail-and-trailhead-data {
+    //   overflow: auto;
+    //   -webkit-overflow-scrolling: touch;
+    // }
   }
 
   .transition(-webkit-transform 0.5s);
@@ -546,6 +546,9 @@ body {
     width: 100%;
     /* ^^ Should this be a device width var? */
     background-color: @white-color;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    -webkit-transform: translate3d(0, 0, 0);
     .trail-data {
       display: inline-block;
       position: relative;


### PR DESCRIPTION
This does two big things:
- Smooths out the open/close animation (done by keeping the layer always layer-backed and animating the transform instead of the `top` property, so there's no re-layout)
- Eliminates the flash of content when the view swaps between normal and fullscreen mode (done by keeping touch scrolling always on, so it stays layer-backed, but preventing scrolling when not in fullscreen via event handlers)

Note the second commit here is a little messy; it's more a proof of concept to demonstrate a way to fix #52.
