### PR TITLE
Fixes issue with copy:js task

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
   watch: {
     scripts: {
       files: ['./www/js/**/*.js'],
-      tasks: ['copy:js']
+      tasks: ['clean:js','copy:js']
     }, //scripts
     less: {
       files: ['./www/less/*'],
@@ -25,6 +25,9 @@ module.exports = function(grunt) {
       tasks: ['copy:html']
     } //html
   }, // watch
+  clean: {
+    js: './platforms/ios/www/js/'
+  },
   copy: {
     css: {
       src: './www/css/application.css',
@@ -32,7 +35,9 @@ module.exports = function(grunt) {
       filter: 'isFile'
     }, //css
     js: {
-      src: './www/js/',
+      expand: true,
+      cwd: './www/js/',
+      src: '*',
       dest: './platforms/ios/www/js/'
     }, //js
     html: {
@@ -44,5 +49,6 @@ module.exports = function(grunt) {
   });
   grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "grunt-contrib-less": "~0.11.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-copy" : "~0.5.0",
+    "grunt-contrib-clean" : "~0.4.1",
     "cordova": "~3.4.1-0.1.0",
     "ios-sim": "~1.9.0"
   },


### PR DESCRIPTION
- Grunt wasn’t properly copying changes to JS files. This commit makes
  grunt clean the production js directory and copies the directory anew
  from the development js directory.
- Also adds grunt-contrib-clean as a dependency for the above.
