### PR TITLE
Fixes #101 - downsizes markers

### DIFF
--- a/www/css/application.css
+++ b/www/css/application.css
@@ -197,6 +197,27 @@ body {
   height: 100%;
   z-index: 1000;
 }
+#map-view .trail-selected .leaflet-marker-icon,
+#map-view .trail-selected .marker-cluster,
+#map-view .trail-selected .marker-cluster div {
+  width: 14px !important;
+  height: 14px !important;
+  margin-left: -7px !important;
+  margin-top: -7px !important;
+}
+#map-view .trail-selected .marker-cluster div {
+  margin-left: 0 !important;
+  margin-top: 0 !important;
+}
+#map-view .trail-selected .marker-cluster div > span {
+  display: none;
+}
+#map-view .trail-selected .leaflet-marker-icon[src="img/trailhead-marker-selected.png"] {
+  margin-left: -17px !important;
+  margin-top: -49px !important;
+  width: 35px !important;
+  height: 50px !important;
+}
 /* SEARCH VIEW */
 #search-view #header {
   height: 140px;

--- a/www/js/application/TrailsCanvasLayer.js
+++ b/www/js/application/TrailsCanvasLayer.js
@@ -2,12 +2,12 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
   'MapTrailLayer',
   function(MapTrailLayer) {
     var pixelRatio = window.devicePixelRatio || 1;
-    
+
     /**
      * TrailsCanvasLayer is a leaflet layer that can render a set of trails
      * as lines on canvas tiles (instead of as SVG). It also contains several
      * optimizations to try and make things a bit faster.
-     * 
+     *
      * TODO: This isn't quite there yet, but it would be sweet if the API
      * here took some cues from LayerGroup -- you could add & remove other
      * sublayers on this layer.
@@ -23,7 +23,7 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
         this.highlighted = null;
         return self;
       },
-      
+
       /**
        * Limits what trails get drawn. Provide a function that returns
        * true or false for whether to render a trail.
@@ -34,7 +34,7 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
           this.redraw();
         }
       },
-      
+
       /**
        * Highlight a particular trail (or null for no highlight).
        * The highlighted trail will be drawn in front of other trails and
@@ -51,10 +51,10 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
           this.redraw();
         }
       },
-      
+
       drawTile: function(canvas, tilePoint, zoom) {
         var pixelScale = Math.pow(0.5, 15 - zoom);
-        
+
         // Calculate the pixel coordinates of the tile and the geographic
         // bounds of the tile. We use these to determine which trails overlap
         // this tile and should be drawn.
@@ -64,9 +64,9 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
           this._map.unproject(L.point(256 * (tilePoint.x - 0.25), 256 * (tilePoint.y + 1.25)), zoom),
           this._map.unproject(L.point(256 * (tilePoint.x + 1.25), 256 * (tilePoint.y - 0.25)), zoom)
         );
-        
+
         var ctx = canvas.getContext('2d');
-        
+
         // Scale the canvas if we're on a retina or hi-res display
         if (pixelRatio !== 1) {
           canvas.width = 256 * pixelRatio;
@@ -75,7 +75,7 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
           canvas.style.height = "256px";
           ctx.scale(pixelRatio, pixelRatio);
         }
-        
+
         // Set drawing styles
         ctx.fillStyle = "#f00";
         ctx.lineWidth = 5;
@@ -92,19 +92,19 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
               highlight = trailLayer;
               return;
             }
-            
+
             this.drawTrail(ctx, pixelScale, tileX, tileY, trailLayer);
           }
         }, this);
-        
+
         if (highlight) {
           this.drawTrail(ctx, pixelScale, tileX, tileY, highlight, highlight.options.highlightStyle);
         }
       },
-      
+
       drawTrail: function(ctx, pixelScale, tileX, tileY, trailLayer, style) {
         style = style || trailLayer.options.style;
-        
+
         // setting context styles turns out to be pretty expensive,
         // so avoid doing so if there's no change.
         if (style !== ctx.lastStyle) {
@@ -113,7 +113,7 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
           ctx.lineWidth = style.weight || 5;
           ctx.lastStyle = style;
         }
-        
+
         trailLayer.eachLayer(function(geoLayer) {
           var lines = layerProjection(geoLayer, this._map);
           for (var j = 0, lenj = lines.length; j < lenj; j++) {
@@ -133,7 +133,7 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
           }
         }, this);
       },
-      
+
       onAdd: function(map) {
         // We don't want to calculate *everything* right away, but after a
         // quick breather, we will (so future panning is speedy)
@@ -143,11 +143,11 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
             TrailsCanvasLayer.processLayer(layer, map)
           });
         }, 2000);
-        
+
         return L.TileLayer.Canvas.prototype.onAdd.apply(this, arguments);
       }
     });
-    
+
     // Internal. Used to lazily retrieve and cache the bounds of a layer.
     function layerBounds(layer) {
       if (!layer.bounds) {
@@ -155,7 +155,7 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
       }
       return layer.bounds;
     }
-    
+
     // Internal. Used to lazily retrieve and cache the projected, simplified
     // line coordinates for a layer.
     function layerProjection(layer, map) {
@@ -168,7 +168,7 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
       }
       return layer.simplified;
     }
-    
+
     // Pre-calculate cached data like bounds and projection for a layer
     TrailsCanvasLayer.processLayer = function processLayer(layer, map) {
       layerBounds(layer);
@@ -176,7 +176,7 @@ angular.module('trails.services').factory('TrailsCanvasLayer', [
         layerProjection(geoLayer, map);
       });
     };
-    
+
     return TrailsCanvasLayer;
   }
 ]);

--- a/www/js/application/services.js
+++ b/www/js/application/services.js
@@ -1188,11 +1188,41 @@
 
     defaults: {
       "maxClusterRadius": 30,
-      "showCoverageOnHover": false
+      "showCoverageOnHover": false,
+
+      // This is a duplicate of the default icon
+      // creation function, which is provided
+      // here as a guide for updating the
+      // cluster icon appearance in the future.
+      // Note that there are three cluster icon
+      // sets: marker-cluster-small, -medium, and -large.
+      "iconCreateFunction": function(cluster) {
+        var childCount = cluster.getChildCount();
+
+        var c = ' marker-cluster-';
+        if (childCount < 10) {
+          c += 'small';
+        } else if (childCount < 100) {
+          c += 'medium';
+        } else {
+          c += 'large';
+        }
+
+        return new L.DivIcon({
+            html: '<div><span>' + childCount + '</span></div>',
+            className: 'marker-cluster' + c,
+            iconSize: new L.Point(40, 40)
+          });
+      }
     },
 
     initialize: function () {
       this.delegate = new L.MarkerClusterGroup(this.attributes);
+    },
+
+    removeLayer: function (layer) {
+      this.delegate.removeLayer(layer.delegate);
+      return this;
     },
 
     addLayer: function (layer) {

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -250,13 +250,13 @@ body {
     border-radius: 2px;
 
     img {
-      height: 40px; 
+      height: 40px;
       width: 40px;
     }
   }
 
   #map-layers {
-    position: fixed;  
+    position: fixed;
     bottom: @footer-height;
     width: 100%;
     z-index: @z-index-1;
@@ -264,9 +264,9 @@ body {
     padding: 0;
     background-color: @white-color;
     border-top: 1px solid @light-gray-color;
-    
+
     .map-layer {
-      width: 100%; 
+      width: 100%;
       list-style-type: none;
       border-bottom: 1px solid @light-gray-color;
       padding: 15px;
@@ -281,7 +281,7 @@ body {
       float: right;
       margin-right: 30px;
       img {
-        width: 20px; 
+        width: 20px;
       }
     }
   }
@@ -292,6 +292,38 @@ body {
     width: 100%;
     height: 100%;
     z-index: @z-index-1;
+  }
+
+  // handle changing of marker sizes when trail is selected
+  .trail-selected {
+
+    .leaflet-marker-icon,
+    .marker-cluster,
+    .marker-cluster div
+    {
+      width: 14px !important;
+      height: 14px !important;
+      margin-left: -7px !important;
+      margin-top: -7px !important;
+    }
+    .marker-cluster div
+    {
+      margin-left: 0 !important;
+      margin-top: 0 !important;
+
+      > span
+      {
+        display:none;
+      }
+    }
+
+    .leaflet-marker-icon[src="img/trailhead-marker-selected.png"]
+    {
+      margin-left: -17px !important;
+      margin-top: -49px !important;
+      width:35px !important;
+      height:50px !important;
+    }
   }
 }
 

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -294,9 +294,11 @@ body {
     z-index: @z-index-1;
   }
 
-  // handle changing of marker sizes when trail is selected
+  // Handle changing of marker sizes when a trailhead is selected.
   .trail-selected {
 
+    // Shrink size of marker icons and marker clusters.
+    // Margin offset needs to be negative half of the width/height
     .leaflet-marker-icon,
     .marker-cluster,
     .marker-cluster div
@@ -306,17 +308,20 @@ body {
       margin-left: -7px !important;
       margin-top: -7px !important;
     }
+    // Position marker cluster centers in shadow properly.
     .marker-cluster div
     {
       margin-left: 0 !important;
       margin-top: 0 !important;
 
+      // Hide numbers in marker clusters.
       > span
       {
         display:none;
       }
     }
 
+    // Don't shrink the selected trailhead.
     .leaflet-marker-icon[src="img/trailhead-marker-selected.png"]
     {
       margin-left: -17px !important;


### PR DESCRIPTION
Downsizes other markers when a trailhead marker is selected.
- Adds a custom CSS class “trail-selected” to map container for when a
  trailhead marker is selected, which allows the markers to be customized
  with CSS.
- Adds a map zoom level class when zooming the map, so custom CSS can
  be added for specific zoom levels, if desired.
- Refactors select/deselect of markers loop so that every marker that
  is not selected doesn’t have a call to its deselect() method, but
  instead the marker that’s clicked is selected and the last marker
  clicked is stored and then deselected when a new marker is clicked.
- Adds the default icon create function for clustering, to set the
  stage for creating custom clustering icons.
- Adds functions to move a marker from a marker cluster to the map and
  vice versa.
- Removes unnecessary whitespace, where noticed.
- Comment out unused methods in controller (see #103)
