### PR TITLE
Fixes #108 - map tile toggle

### DIFF
--- a/www/js/application/controllers.js
+++ b/www/js/application/controllers.js
@@ -241,6 +241,7 @@
       function toggleMapTileLayer () {
         currentLayer = (currentLayer === "terrain" ? "satellite" : "terrain");
         mapTileLayer.setUrl(MapTileLayer.INDEX[currentLayer].url);
+        toggleView(TRAILS_VIEW);
       }
 
       $scope.toggleMapTileLayer = toggleMapTileLayer;


### PR DESCRIPTION
When map tile toggle was clicked the view wasn’t changing. This commit
adds a toggleView to the trails view when the map tile toggle is
clicked.
