### PR TITLE
Fixes #100 - truncate long agency name

### DIFF
--- a/www/css/application.css
+++ b/www/css/application.css
@@ -834,9 +834,6 @@ body {
   padding-bottom: 10px;
 }
 #notifications-view #content #notification-source .source-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  -webkit-text-overflow: ellipsis;
   display: inline-block;
   position: relative;
   vertical-align: top;
@@ -846,6 +843,13 @@ body {
   width: 80%;
   margin: 0 0 0 0;
   height: 48px;
+}
+#notifications-view #content #notification-source .source-name span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
 }
 #notifications-view #content #notification-source .source-logo {
   display: inline-block;

--- a/www/index.html
+++ b/www/index.html
@@ -59,7 +59,11 @@
             </nav>
             <section id="notification-source">
               <div class="source-name-container">
-                <p class="source-name">{{ steward.get('name') }}</p>
+                <p class="source-name">
+                  <span>
+                    {{ steward.get('name') }}
+                  </span>
+                </p>
                 <img class="source-logo" src="img/nps.png"></img>
               </div>
               <nav class="notification-tabs">

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -979,9 +979,6 @@ body {
         padding-bottom: 10px;
       }
       .source-name {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        -webkit-text-overflow: ellipsis;
         display: inline-block;
         position: relative;
         vertical-align: top;
@@ -991,6 +988,14 @@ body {
         width: 80%;
         margin: 0 0 0 0;
         height: 48px;
+        span
+        {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          display: -webkit-box;
+        }
       }
       .source-logo {
         display: inline-block;


### PR DESCRIPTION
Agency name would get cropped if it was greater than 2 lines. This
commit adds an ellipsis to the name if that happens using proprietary
-webkit- CSS attributes.

@alanjosephwilliams ready for review and merge.

![screen shot 2014-05-05 at 7 56 35 pm](https://cloud.githubusercontent.com/assets/704760/2885655/8422523c-d4ca-11e3-83a3-0e4bac1bb942.png)
