### PR TITLE
Fixes #120 - dynamic steward pagination

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -47,14 +47,14 @@
 
           <header>
             <nav id="sources-nav">
-              <a href="#" class="previous-steward" ng-click="previous()">
-                <i class="fa fa-chevron-left" ng-class="{active: canPrevious()}"></i>
+              <a href="#" class="previous-steward" ng-click="previousSteward()">
+                <i class="fa fa-chevron-left" ng-class="{active: canPreviousSteward()}"></i>
               </a>
               <div class="nav-text">
-                <p>1 of 3 Stewards</p>
+                <p>{{currentStewardPosition()}} of {{ stewards.length }} Stewards</p>
               </div>
-              <a href="#" class="next-steward" ng-click="next()">
-                <i class="fa fa-chevron-right" ng-class="{active: canNext()}"></i>
+              <a href="#" class="next-steward" ng-click="nextSteward()">
+                <i class="fa fa-chevron-right" ng-class="{active: canNextSteward()}"></i>
               </a>
             </nav>
             <section id="notification-source">

--- a/www/js/application/controllers.js
+++ b/www/js/application/controllers.js
@@ -14,7 +14,7 @@
 
       // Instantiate variables
 
-      var index = 0;
+      var index = 0; // the currently showing steward.
 
       // Wait until all models have been
       // loaded to instantiate variables
@@ -26,16 +26,16 @@
 
       // Navigate to next steward
 
-      $scope.next = function () {
-        if ( canNext() ) {
+      $scope.nextSteward = function () {
+        if ( canNextSteward() ) {
           $scope.steward = $scope.stewards[++index];
         }
       }
 
       // Navigate to previous steward
 
-      $scope.previous = function () {
-        if ( canPrevious() ) {
+      $scope.previousSteward = function () {
+        if ( canPreviousSteward() ) {
           $scope.steward = $scope.stewards[--index];
         }
       }
@@ -43,23 +43,26 @@
       // Returns whether or not a previous
       // steward exists
 
-      function canPrevious () {
+      function canPreviousSteward () {
         return index > 0;
       }
-
-      $scope.canPrevious = canPrevious;
+      $scope.canPreviousSteward = canPreviousSteward;
 
       // Returns whether or not a subsequent
       // steward exists
 
-      function canNext () {
+      function canNextSteward () {
         if ($scope.stewards)
           return index < ($scope.stewards.length - 1);
         else
           return false;
       }
+      $scope.canNextSteward = canNextSteward;
 
-      $scope.canNext = canNext;
+      function currentStewardPosition() {
+        return index+1;
+      }
+      $scope.currentStewardPosition = currentStewardPosition;
 
       // Watch current steward, and set notifications
       // when it changes


### PR DESCRIPTION
- Makes pagination of Stewards in notifications view dynamic so it says
  “1 of 3 Stewards,” “2 of 3 Stewards,” etc. when navigating between
  agencies.
- Amends next/previous method names related to stewards to include
  “Steward,” such as “canNext()” becomes “canNextSteward().” This makes
  it clearer what the methods do and aligns them with the names given to
  the trail methods that perform similar actions.
- Adds `currentStewardPosition` method for retrieving the current index
  position of the stewards array. This is used to update the stewards
  pagination control with the currently shown steward position in the
  list of total stewards.
