### PR TITLE
Fixes #90 - steward carousel

### DIFF
--- a/www/css/application.css
+++ b/www/css/application.css
@@ -416,6 +416,10 @@ body {
   text-align: center;
   left: 20px;
 }
+#trail-view .trail-nav .trail-trailhead .change-trail .previous-trail .fa.hidden,
+#trail-view .trail-nav .trail-trailhead .change-trail .next-trail .fa.hidden {
+  opacity: 0.0 !important;
+}
 #trail-view .trail-nav .trail-trailhead .change-trail .previous-trail .fa,
 #trail-view .trail-nav .trail-trailhead .change-trail .next-trail .fa {
   margin-top: 9px;

--- a/www/index.html
+++ b/www/index.html
@@ -48,13 +48,13 @@
           <header>
             <nav id="sources-nav">
               <a href="#" class="previous-steward" ng-click="previousSteward()">
-                <i class="fa fa-chevron-left" ng-class="{active: canPreviousSteward()}"></i>
+                <i class="fa fa-chevron-left active"></i>
               </a>
               <div class="nav-text">
                 <p>{{currentStewardPosition()}} of {{ stewards.length }} Stewards</p>
               </div>
               <a href="#" class="next-steward" ng-click="nextSteward()">
-                <i class="fa fa-chevron-right" ng-class="{active: canNextSteward()}"></i>
+                <i class="fa fa-chevron-right active"></i>
               </a>
             </nav>
             <section id="notification-source">
@@ -120,11 +120,11 @@
           <div class="trail-trailhead">
             <div class="change-trail">
               <a href="#" class="previous-trail" ng-click="previousTrail()">
-                <i class="fa fa-chevron-left" ng-class="{active: canPreviousTrail()}"></i>
+                <i class="fa fa-chevron-left active" ng-class="{hidden:hasMoreTrails()}"></i>
               </a>
               <p class="trailhead-index">{{ selectedTrails.indexOf(selectedTrail) + 1 }} of {{ selectedTrails.length }}</p>
               <a href="#" class="next-trail" ng-click="nextTrail()">
-                <i class="fa fa-chevron-right" ng-class="{active: canNextTrail()}"></i>
+                <i class="fa fa-chevron-right active" ng-class="{hidden:hasMoreTrails()}"></i>
               </a>
             </div>
           </div>

--- a/www/js/application/controllers.js
+++ b/www/js/application/controllers.js
@@ -27,37 +27,18 @@
       // Navigate to next steward
 
       $scope.nextSteward = function () {
-        if ( canNextSteward() ) {
-          $scope.steward = $scope.stewards[++index];
-        }
+        if ( index >= $scope.stewards.length-1 )
+          index = -1;
+        $scope.steward = $scope.stewards[++index];
       }
 
       // Navigate to previous steward
 
       $scope.previousSteward = function () {
-        if ( canPreviousSteward() ) {
-          $scope.steward = $scope.stewards[--index];
-        }
+        if ( index <= 0 )
+          index = $scope.stewards.length;
+        $scope.steward = $scope.stewards[--index];
       }
-
-      // Returns whether or not a previous
-      // steward exists
-
-      function canPreviousSteward () {
-        return index > 0;
-      }
-      $scope.canPreviousSteward = canPreviousSteward;
-
-      // Returns whether or not a subsequent
-      // steward exists
-
-      function canNextSteward () {
-        if ($scope.stewards)
-          return index < ($scope.stewards.length - 1);
-        else
-          return false;
-      }
-      $scope.canNextSteward = canNextSteward;
 
       function currentStewardPosition() {
         return index+1;
@@ -526,32 +507,24 @@
 
       $scope.nextTrail = function () {
         var index  = $scope.selectedTrails.indexOf($scope.selectedTrail);
-        if ( canNextTrail() ) {
-          $scope.selectedTrail = $scope.selectedTrails[index + 1];
-        }
+        if ( index >= $scope.selectedTrails.length-1 )
+          index = -1;
+        $scope.selectedTrail = $scope.selectedTrails[++index];
       }
-
-      function canNextTrail () {
-        return $scope.selectedTrails.indexOf($scope.selectedTrail) < ($scope.selectedTrails.length - 1)
-      }
-
-      $scope.canNextTrail = canNextTrail;
 
       $scope.previousTrail = function () {
         var index = $scope.selectedTrails.indexOf($scope.selectedTrail);
-        if ( canPreviousTrail() ) {
-          $scope.selectedTrail = $scope.selectedTrails[index - 1];
-        }
+        if ( index <= 0 )
+          index = $scope.selectedTrails.length;
+        $scope.selectedTrail = $scope.selectedTrails[--index];
       }
 
-      function canPreviousTrail () {
-        return $scope.selectedTrails.indexOf($scope.selectedTrail) > 0;
+      $scope.hasMoreTrails = function () {
+        return ($scope.selectedTrails.length <= 1);
       }
 
-      $scope.canPreviousTrail = canPreviousTrail;
-
-      function closeTrailView () {
-        $scope.fullscreen = false; 
+     function closeTrailView () {
+        $scope.fullscreen = false;
         deselectTrailHead($scope.selectedTrailHead);
       }
 

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -546,6 +546,9 @@ body {
         // Chevron icons for trails.
         .previous-trail,
         .next-trail {
+          .fa.hidden {
+            opacity: 0.0 !important;
+          }
           .fa {
             margin-top: 9px;
             font-size: 24px;


### PR DESCRIPTION
- Makes the Steward and Trail next/prev buttons act like a carousel, so
  that when they reach the end or beginning they loop around to the
  beginning or end.
- Also hides the chevron arrows for the trails when there is only 1 of
  1 trails.

![screen shot 2014-05-12 at 2 41 31 am](https://cloud.githubusercontent.com/assets/704760/2942782/a28d3798-d9b9-11e3-8034-6e8ff540213d.png)

![screen shot 2014-05-12 at 2 41 09 am](https://cloud.githubusercontent.com/assets/704760/2942784/a28e579a-d9b9-11e3-8741-201086b7aeb8.png)

![screen shot 2014-05-12 at 2 40 54 am](https://cloud.githubusercontent.com/assets/704760/2942783/a28d7c76-d9b9-11e3-9271-daef2456809c.png)

@alanjosephwilliams ready for review and merge!
