### PR TITLE
Fixes #114 - animates closing of trail details

### DIFF
--- a/www/css/application.css
+++ b/www/css/application.css
@@ -566,33 +566,31 @@ body {
 }
 #trail-view #trail-and-trailhead-data .trailhead-title-field {
   display: block;
+  margin: 10px 0;
+  margin-bottom: 20px;
   position: relative;
-  height: 1em;
 }
 #trail-view #trail-and-trailhead-data .trailhead-title-field .trailhead-icon {
   display: inline-block;
   position: relative;
-  float: left;
   width: auto;
-  margin: .5em 0;
+  margin-right: 10px;
+  vertical-align: middle;
 }
 #trail-view #trail-and-trailhead-data .trailhead-title-field .trailhead-title {
-  position: relative;
-  display: inline-block;
   font-family: 'Merriweather Sans', sans-serif;
   font-size: 12px;
-  float: left;
-  width: auto;
-  max-width: 50%;
-  margin: .5em 10px;
-  font-weight: 700;
-}
-#trail-view #trail-and-trailhead-data .trailhead-title-field .trailhead-address {
   display: inline-block;
   position: relative;
-  float: right;
   width: auto;
-  margin: .5em 0 1em 0;
+  max-width: 50%;
+  margin: 0;
+  font-weight: 700;
+  vertical-align: middle;
+}
+#trail-view #trail-and-trailhead-data .trailhead-title-field .trailhead-address {
+  width: auto;
+  margin: 0;
   font-family: 'Source Sans Pro', sans-serif;
   font-size: 12px;
   padding: 6px;
@@ -600,6 +598,10 @@ body {
   border-radius: 2px;
   color: #f6f6f6;
   text-decoration: none;
+  margin-top: -13px;
+  position: absolute;
+  right: 0;
+  top: 50%;
 }
 #trail-view #trail-and-trailhead-data .photo-box {
   margin-left: -20px;

--- a/www/css/application.css
+++ b/www/css/application.css
@@ -525,8 +525,6 @@ body {
   -webkit-overflow-scrolling: touch;
 }
 #trail-view #trail-and-trailhead-data #trail-data-header {
-  display: inline-block;
-  position: relative;
   vertical-align: middle;
   width: auto;
   margin: 0;
@@ -538,7 +536,7 @@ body {
   line-height: 1.2em;
   font-family: 'Merriweather Sans', sans-serif;
   font-size: 22px;
-  margin: 10px 20px 0 20px;
+  margin: 10px 0px;
 }
 #trail-view #trail-and-trailhead-data #trail-data-header .trail-attribute-distance {
   width: auto;
@@ -549,8 +547,6 @@ body {
   display: inline-block;
   position: relative;
   margin-top: 0;
-  margin-left: 20px;
-  margin-right: 20px;
   margin-bottom: 10px;
   font-weight: 400;
 }
@@ -565,7 +561,6 @@ body {
   float: right;
   text-align: right;
   margin-top: 0;
-  margin-right: 20px;
   margin-bottom: 10px;
   font-weight: 400;
 }
@@ -573,7 +568,6 @@ body {
   display: block;
   position: relative;
   height: 1em;
-  margin: 0 20px;
 }
 #trail-view #trail-and-trailhead-data .trailhead-title-field .trailhead-icon {
   display: inline-block;

--- a/www/css/application.css
+++ b/www/css/application.css
@@ -373,73 +373,64 @@ body {
   font-size: 22px;
 }
 /* Trail View - AJW*/
-/* Trail View - AJW*/
 #trail-view {
-  -webkit-transition: -webkit-transform 0.5s;
-  -moz-transition: -webkit-transform 0.5s;
-  -ms-transition: -webkit-transform 0.5s;
-  -o-transition: -webkit-transform 0.5s;
-  -webkit-transform: translate3d(0, 20px, 0);
-  /* Footer Height, Flush */
-  transform: translate3d(0px, 20px, 0);
   position: fixed;
-  width: 100%;
   background-color: #f6f6f6;
-  z-index: 4000;
-  top: 0;
-  bottom: 60px;
+  width: 100%;
+  height: 100%;
+  z-index: 3000;
   right: 0;
   left: 0;
+  margin-top: 20px;
+  -webkit-transform: translate3d(0, 0, 0);
+  -webkit-box-sizing: border-box;
 }
 #trail-view.fullscreen {
-  -webkit-transform: translate3d(0, 20px, 0) !important;
+  top: 0 !important;
 }
-#trail-view .trail-nav {
-  display: inline-block;
+#trail-view.closed {
+  top: 100% !important;
+}
+#trail-view.transition {
+  -webkit-transition: top 0.5s;
+}
+#trail-view #trail-nav {
   position: relative;
   height: 2.5em;
   width: 100%;
   background-color: #5c795a;
   border-bottom: 5px solid #f6f6f6;
 }
-#trail-view .trail-nav .trail-trailhead {
+#trail-view #trail-nav .change-trail {
   display: inline-block;
   position: relative;
-  height: 100%;
-  vertical-align: middle;
-}
-#trail-view .trail-nav .trail-trailhead .change-trail {
-  display: inline-block;
-  position: relative;
-  width: 100%;
-  height: auto;
   text-align: center;
-  left: 20px;
+  margin-left: 20px;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .previous-trail .fa.hidden,
-#trail-view .trail-nav .trail-trailhead .change-trail .next-trail .fa.hidden {
+#trail-view #trail-nav .change-trail .previous-trail .fa.hidden,
+#trail-view #trail-nav .change-trail .next-trail .fa.hidden {
   opacity: 0.0 !important;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .previous-trail .fa,
-#trail-view .trail-nav .trail-trailhead .change-trail .next-trail .fa {
+#trail-view #trail-nav .change-trail .previous-trail .fa,
+#trail-view #trail-nav .change-trail .next-trail .fa {
   margin-top: 9px;
   font-size: 24px;
   color: #242424;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .previous-trail .fa.active,
-#trail-view .trail-nav .trail-trailhead .change-trail .next-trail .fa.active {
+#trail-view #trail-nav .change-trail .previous-trail .fa.active,
+#trail-view #trail-nav .change-trail .next-trail .fa.active {
   color: #f6f6f6;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .previous-trail {
+#trail-view #trail-nav .change-trail .previous-trail {
   display: inline-block;
   position: relative;
   padding-right: 10px;
   float: left;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .previous-trail:active {
+#trail-view #trail-nav .change-trail .previous-trail:active {
   opacity: .75;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .previous-trail p {
+#trail-view #trail-nav .change-trail .previous-trail p {
   display: inline-block;
   position: relative;
   float: left;
@@ -447,7 +438,7 @@ body {
   font-size: 12px;
   font-weight: 400;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .trailhead-index {
+#trail-view #trail-nav .change-trail .trailhead-index {
   display: inline-block;
   position: relative;
   float: left;
@@ -458,15 +449,15 @@ body {
   color: #f6f6f6;
   margin: 1em 0 0 0;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .next-trail {
+#trail-view #trail-nav .change-trail .next-trail {
   display: inline-block;
   position: relative;
   padding-left: 8px;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .next-trail:active {
+#trail-view #trail-nav .change-trail .next-trail:active {
   opacity: .75;
 }
-#trail-view .trail-nav .trail-trailhead .change-trail .next-trail p {
+#trail-view #trail-nav .change-trail .next-trail p {
   display: inline-block;
   position: relative;
   float: right;
@@ -475,7 +466,7 @@ body {
   font-size: 12px;
   font-weight: 400;
 }
-#trail-view .trail-nav .more-btn-tab {
+#trail-view #trail-nav .more-btn-tab {
   display: block;
   position: absolute;
   left: 40%;
@@ -485,19 +476,19 @@ body {
   background-color: #f6f6f6;
   border-radius: 2px 2px 0 0;
 }
-#trail-view .trail-nav .more-btn-tab .more-btn {
+#trail-view #trail-nav .more-btn-tab .more-btn {
   display: block;
   height: auto;
   padding: 5% 0 10% 0;
   width: auto;
   text-align: center;
 }
-#trail-view .trail-nav .more-btn-tab .more-btn .fa {
+#trail-view #trail-nav .more-btn-tab .more-btn .fa {
   height: 20px;
   text-align: center;
   color: #5c795a;
 }
-#trail-view .trail-nav .more-btn-label {
+#trail-view #trail-nav .more-btn-label {
   display: inline-block;
   position: relative;
   font-family: 'Source Sans Pro', sans-serif;
@@ -506,7 +497,7 @@ body {
   margin: 1.25em 0 0 10px;
   color: #f6f6f6;
 }
-#trail-view .trail-nav .close-btn-label {
+#trail-view #trail-nav .close-btn-label {
   display: inline-block;
   position: relative;
   float: right;
@@ -516,42 +507,31 @@ body {
   margin: 1.25em 10px 0 0;
   color: #f6f6f6;
 }
-#trail-view .trail-nav .close-btn {
+#trail-view #trail-nav .close-btn {
   float: right;
   padding: 5px 10px;
 }
-#trail-view .trail-nav .close-btn .fa {
+#trail-view #trail-nav .close-btn .fa {
   font-size: 30px;
   color: #f6f6f6;
 }
-#trail-view .trail-and-trailhead-data {
-  position: absolute;
-  top: 45px;
-  /* green nav bar, plus hardware padding, plus border */
-  bottom: 0;
-  right: 0;
-  left: 0;
-  display: inline-block;
-  background-color: #f6f6f6;
-  overflow: auto;
+#trail-view #trail-and-trailhead-data {
+  padding: 0 20px;
+  height: 100%;
+  padding-bottom: 110px;
+  box-sizing: border-box;
+  background: #f6f6f6;
+  overflow: scroll;
   -webkit-overflow-scrolling: touch;
-  -webkit-transform: translate3d(0, 0, 0);
 }
-#trail-view .trail-and-trailhead-data .trail-data {
-  display: inline-block;
-  position: relative;
-  height: auto;
-  width: 100%;
-  background-color: #f6f6f6;
-}
-#trail-view .trail-and-trailhead-data .trail-data .trail-attributes {
+#trail-view #trail-and-trailhead-data #trail-data-header {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   width: auto;
   margin: 0;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trail-attributes .trail-title {
+#trail-view #trail-and-trailhead-data #trail-data-header .trail-title {
   position: relative;
   display: inline-block;
   min-width: 75%;
@@ -560,7 +540,7 @@ body {
   font-size: 22px;
   margin: 10px 20px 0 20px;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trail-attributes .trail-attribute-distance {
+#trail-view #trail-and-trailhead-data #trail-data-header .trail-attribute-distance {
   width: auto;
   vertical-align: top;
   padding-top: 10px;
@@ -574,7 +554,7 @@ body {
   margin-bottom: 10px;
   font-weight: 400;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trail-attributes .trail-attribute-length {
+#trail-view #trail-and-trailhead-data #trail-data-header .trail-attribute-length {
   width: auto;
   vertical-align: top;
   padding-top: 10px;
@@ -589,20 +569,20 @@ body {
   margin-bottom: 10px;
   font-weight: 400;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trailhead-title-field {
+#trail-view #trail-and-trailhead-data .trailhead-title-field {
   display: block;
   position: relative;
   height: 1em;
   margin: 0 20px;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trailhead-title-field .trailhead-icon {
+#trail-view #trail-and-trailhead-data .trailhead-title-field .trailhead-icon {
   display: inline-block;
   position: relative;
   float: left;
   width: auto;
   margin: .5em 0;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trailhead-title-field .trailhead-title {
+#trail-view #trail-and-trailhead-data .trailhead-title-field .trailhead-title {
   position: relative;
   display: inline-block;
   font-family: 'Merriweather Sans', sans-serif;
@@ -613,7 +593,7 @@ body {
   margin: .5em 10px;
   font-weight: 700;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trailhead-title-field .trailhead-address {
+#trail-view #trail-and-trailhead-data .trailhead-title-field .trailhead-address {
   display: inline-block;
   position: relative;
   float: right;
@@ -627,18 +607,18 @@ body {
   color: #f6f6f6;
   text-decoration: none;
 }
-#trail-view .trail-and-trailhead-data .trail-data .photo-box {
-  display: inline-block;
-  position: relative;
-  width: 100%;
+#trail-view #trail-and-trailhead-data .photo-box {
+  margin-left: -20px;
+  margin-right: -20px;
 }
-#trail-view .trail-and-trailhead-data .trail-data .photo-box img {
+#trail-view #trail-and-trailhead-data .photo-box img {
   height: auto;
   max-width: 100%;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trail-subhead {
-  display: inline-block;
-  position: relative;
+#trail-view #trail-and-trailhead-data .trailhead-data {
+  padding-top: 10px;
+}
+#trail-view #trail-and-trailhead-data .trailhead-data .trail-subhead {
   width: 100%;
   font-family: 'Source Sans Pro', sans-serif;
   font-size: 12px;
@@ -646,14 +626,14 @@ body {
   color: #a3a3a3;
   margin: 0;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trail-icons {
+#trail-view #trail-and-trailhead-data .trailhead-data .trail-icons {
   width: auto;
   display: inline-block;
   position: relative;
   text-align: justify;
   margin: 10px 0;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trail-icons .icon-box {
+#trail-view #trail-and-trailhead-data .trailhead-data .trail-icons .icon-box {
   display: inline-block;
   width: 30px;
   height: 30px;
@@ -661,21 +641,21 @@ body {
   margin-right: 20px;
   margin-bottom: 10px;
 }
-#trail-view .trail-and-trailhead-data .trail-data .trail-icons .icon-box .icon {
+#trail-view #trail-and-trailhead-data .trailhead-data .trail-icons .icon-box .icon {
   height: 100%;
   width: 100%;
 }
-#trail-view .trail-and-trailhead-data .trail-data .amenities {
+#trail-view #trail-and-trailhead-data .trailhead-data .amenities {
   display: inline-block;
   position: relative;
   width: 100%;
   margin: 10px 0;
   text-align: center;
 }
-#trail-view .trail-and-trailhead-data .trail-data .amenities td {
+#trail-view #trail-and-trailhead-data .trailhead-data .amenities td {
   text-align: left;
 }
-#trail-view .trail-and-trailhead-data .trail-data .amenities .amenity {
+#trail-view #trail-and-trailhead-data .trailhead-data .amenities .amenity {
   text-align: left;
   margin: 5px 20px 5px 0px;
   width: auto;
@@ -684,39 +664,29 @@ body {
   font-size: 12px;
   font-weight: 700;
 }
-#trail-view .trail-and-trailhead-data .trail-data .fa {
+#trail-view #trail-and-trailhead-data .trailhead-data .fa {
   margin-right: .2em;
   font-size: 20px;
 }
-#trail-view .trail-and-trailhead-data .trail-data p {
+#trail-view #trail-and-trailhead-data .trailhead-data p {
   display: inline-block;
   position: relative;
   line-height: 1.4em;
   font-weight: 400;
 }
-#trail-view .trail-and-trailhead-data .trailhead-data {
-  -webkit-transform: translate3d(0, 0, 0);
-  display: inline-block;
-  position: relative;
-  height: auto;
-  padding-left: 20px;
-  padding-right: 20px;
-  padding-top: 10px;
-  background-color: #f6f6f6;
-}
-#trail-view .trail-and-trailhead-data .trailhead-data .trail-body {
+#trail-view #trail-and-trailhead-data .trailhead-data .trail-body {
   font-family: 'Merriweather Sans', sans-serif, serif;
   font-size: 12px;
   font-weight: 400;
 }
-#trail-view .trail-and-trailhead-data .trailhead-data .trailhead-steward {
+#trail-view #trail-and-trailhead-data .trailhead-data .trailhead-steward {
   position: relative;
   display: inline-block;
   width: 100%;
   margin-top: 10px;
   margin-bottom: 40px;
 }
-#trail-view .trail-and-trailhead-data .trailhead-data .trailhead-steward p {
+#trail-view #trail-and-trailhead-data .trailhead-data .trailhead-steward p {
   margin: 0;
   font-family: 'Merriweather Sans', sans-serif;
   font-size: 12px;

--- a/www/index.html
+++ b/www/index.html
@@ -114,39 +114,36 @@
 
       </section>
 
-
-      <div id="trail-view" ng-show="view === 'trails'" hm-swipe-left="nextTrail()" hm-swipe-right="previousTrail()" ng-class="{ fullscreen: fullscreen }" ng-cloak>
-        <div class="trail-nav" hm-drag-up="drag($event)" hm-drag-down="drag($event)">
-          <div class="trail-trailhead">
-            <div class="change-trail">
-              <a href="#" class="previous-trail" ng-click="previousTrail()">
-                <i class="fa fa-chevron-left active" ng-class="{hidden:hasMoreTrails()}"></i>
-              </a>
-              <p class="trailhead-index">{{ selectedTrails.indexOf(selectedTrail) + 1 }} of {{ selectedTrails.length }}</p>
-              <a href="#" class="next-trail" ng-click="nextTrail()">
-                <i class="fa fa-chevron-right active" ng-class="{hidden:hasMoreTrails()}"></i>
-              </a>
-            </div>
+      <section id="trail-view" class="transition closed" hm-swipe-left="nextTrail()" hm-swipe-right="previousTrail()" ng-cloak>
+        <header id="trail-nav" hm-drag-up="drag($event)" hm-drag-down="drag($event)">
+          <div class="change-trail">
+            <a href="#" class="previous-trail" ng-click="previousTrail()">
+              <i class="fa fa-chevron-left active" ng-class="{hidden:hasMoreTrails()}"></i>
+            </a>
+            <p class="trailhead-index">{{ selectedTrails.indexOf(selectedTrail) + 1 }} of {{ selectedTrails.length }}</p>
+            <a href="#" class="next-trail" ng-click="nextTrail()">
+              <i class="fa fa-chevron-right active" ng-class="{hidden:hasMoreTrails()}"></i>
+            </a>
           </div>
           <div class="more-btn-tab">
-            <a href="#" class="more-btn" ng-click="fullscreen = !fullscreen">
-                <i class="fa fa-chevron-down" ng-show="fullscreen" ng-cloak></i>
-                <i class="fa fa-chevron-up" ng-show="!fullscreen" ng-cloak></i>
+            <a href="#" class="more-btn" ng-click="toggleTrailView()">
+                <i class="fa fa-chevron-down" ng-show="isFullscreen()" ng-cloak></i>
+                <i class="fa fa-chevron-up" ng-show="!isFullscreen()" ng-cloak></i>
             </a>
           </div>
           <a href="#" class="close-btn" ng-click="closeTrailView()">
             <i class="fa fa-times"></i>
           </a>
-        </div>
-        <div class="trail-and-trailhead-data">
-          <div class="trail-data">
-            <div class="trail-attributes">
-              <h3 class="trail-title">{{ selectedTrail.get('name') }}</h3>
-              <h5 class="trail-attribute-distance">
-                <distance-from-trailhead trailhead="selectedTrailHead" position="geoposition"/>
-              </h5>
-              <h5 class="trail-attribute-length">{{ selectedTrail.getLength().toFixed(2) }} mi long</h5>
-            </div>
+        </header>
+        <article id="trail-and-trailhead-data">
+          <header id="trail-data-header">
+            <h3 class="trail-title">{{ selectedTrail.get('name') }}</h3>
+            <h5 class="trail-attribute-distance">
+              <distance-from-trailhead trailhead="selectedTrailHead" position="geoposition"/>
+            </h5>
+            <h5 class="trail-attribute-length">{{ selectedTrail.getLength().toFixed(2) }} mi long</h5>
+          </header>
+          <section class="trail-data-content">
             <div class="trailhead-title-field">
               <i class="trailhead-icon fa fa-map-marker"></i>
               <p class="trailhead-title">{{ selectedTrailHead.get('name') }} Trailhead</p>
@@ -196,9 +193,9 @@
                 </p>
               </div>
             </div>
-          </div>
-        </div>
-      </div>
+          </section>
+        </article>
+      </section>
 
       <div id="search-view" ng-show="view === 'search'" ng-cloak>
 

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -664,8 +664,6 @@ body {
     -webkit-overflow-scrolling: touch;
 
     #trail-data-header {
-      display: inline-block;
-      position: relative;
       vertical-align: middle;
       width: auto;
       margin: 0;
@@ -676,7 +674,7 @@ body {
         line-height: 1.2em;
         font-family: @font-display;
         font-size: @large-font;
-        margin: 10px 20px 0 20px;
+        margin: 10px 0px;
       }
       .trail-attribute-distance {
         width: auto;
@@ -687,8 +685,6 @@ body {
         display: inline-block;
         position: relative;
         margin-top: 0;
-        margin-left: 20px;
-        margin-right: 20px;
         margin-bottom: 10px;
         font-weight: 400;
       }
@@ -703,7 +699,6 @@ body {
         float: right;
         text-align: right;
         margin-top: 0;
-        margin-right: 20px;
         margin-bottom: 10px;
         font-weight: 400;
       }
@@ -712,7 +707,6 @@ body {
       display: block;
       position: relative;
       height: 1em;
-      margin: 0 20px;
       .trailhead-icon {
         display: inline-block;
         position: relative;

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -705,32 +705,30 @@ body {
     }
     .trailhead-title-field {
       display: block;
+      margin: 10px 0;
+      margin-bottom: 20px;
       position: relative;
-      height: 1em;
       .trailhead-icon {
         display: inline-block;
         position: relative;
-        float: left;
         width: auto;
-        margin: .5em 0;
+        margin-right: 10px;
+        vertical-align: middle;
       }
       .trailhead-title {
-        position: relative;
-        display: inline-block;
         font-family: @font-display;
         font-size: @small-font;
-        float: left;
-        width: auto;
-        max-width: 50%;
-        margin: .5em 10px;
-        font-weight: 700;
-      }
-      .trailhead-address {
         display: inline-block;
         position: relative;
-        float: right;
         width: auto;
-        margin: .5em 0 1em 0;
+        max-width: 50%;
+        margin: 0;
+        font-weight: 700;
+        vertical-align: middle;
+      }
+      .trailhead-address {
+        width: auto;
+        margin: 0;
         font-family: @font-context;
         font-size: @small-font;
         padding: 6px;
@@ -738,6 +736,10 @@ body {
         border-radius: 2px;
         color: @white-color;
         text-decoration: none;
+        margin-top: -13px;
+        position: absolute;
+        right: 0;
+        top: 50%;
       }
     }
     .photo-box {

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -499,111 +499,104 @@ body {
 }
 
 /* Trail View - AJW*/
-/* Trail View - AJW*/
 #trail-view {
 
   &.fullscreen {
-    -webkit-transform: translate3d(0, 20px, 0) !important;
-    // .trail-and-trailhead-data {
-    //   overflow: auto;
-    //   -webkit-overflow-scrolling: touch;
-    // }
+    top: 0 !important;
   }
 
-  .transition(-webkit-transform 0.5s);
+  &.closed {
+    top: 100% !important;
+  }
 
-  -webkit-transform: translate3d(0, 20px, 0); /* Footer Height, Flush */
-  transform: translate3d(0px, 20px, 0);
+  &.transition {
+    -webkit-transition: top 0.5s;
+  }
+
   position: fixed;
   background-color: @white-color;
   width: 100%;
-  background-color: @white-color;
-  z-index: @z-index-4;
-  top: 0;
-  bottom: @footer-height;
+  height: 100%;
+  z-index: @z-index-3;
   right: 0;
   left: 0;
-  .trail-nav {
-    display: inline-block;
+  margin-top: 20px;
+  -webkit-transform: translate3d(0, 0, 0);
+  -webkit-box-sizing:border-box;
+
+  #trail-nav {
     position: relative;
     height: 2.5em;
     width: 100%;
     background-color: @green-color;
     border-bottom: 5px solid @white-color;
-    .trail-trailhead {
+
+    .change-trail {
       display: inline-block;
       position: relative;
-      height: 100%;
-      vertical-align: middle;
-      .change-trail {
+      text-align: center;
+      margin-left: 20px;
+
+      // Chevron icons for trails.
+      .previous-trail,
+      .next-trail {
+        .fa.hidden {
+            opacity: 0.0 !important;
+        }
+        .fa {
+          margin-top: 9px;
+          font-size: 24px;
+          color: @gray-color;
+        }
+        .fa.active
+        {
+          color: @white-color;
+        }
+      }
+
+      .previous-trail {
         display: inline-block;
         position: relative;
-        width: 100%;
-        height: auto;
-        text-align: center;
-        left: 20px;
-
-        // Chevron icons for trails.
-        .previous-trail,
-        .next-trail {
-          .fa.hidden {
-            opacity: 0.0 !important;
-          }
-          .fa {
-            margin-top: 9px;
-            font-size: 24px;
-            color: @gray-color;
-          }
-          .fa.active
-          {
-            color: @white-color;
-          }
+        padding-right: 10px;
+        float: left;
+        &:active {
+          opacity: .75;
         }
-
-        .previous-trail {
-          display: inline-block;
-          position: relative;
-          padding-right: 10px;
-          float: left;
-          &:active {
-            opacity: .75;
-          }
-          p {
-            display: inline-block;
-            position: relative;
-            float: left;
-            margin: 1em 1em 0 0;
-            font-size: @small-font;
-            font-weight: 400;
-          }
-        }
-        .trailhead-index {
+        p {
           display: inline-block;
           position: relative;
           float: left;
-          font-family: @font-context;
-          font-size: 12px;
+          margin: 1em 1em 0 0;
+          font-size: @small-font;
           font-weight: 400;
-          text-align: center;
-          color: @white-color;
-          margin: 1em 0 0 0;
         }
-        .next-trail {
+      }
+      .trailhead-index {
+        display: inline-block;
+        position: relative;
+        float: left;
+        font-family: @font-context;
+        font-size: 12px;
+        font-weight: 400;
+        text-align: center;
+        color: @white-color;
+        margin: 1em 0 0 0;
+      }
+      .next-trail {
+        display: inline-block;
+        position: relative;
+        padding-left: 8px;
+        &:active {
+          opacity: .75;
+        }
+        p {
           display: inline-block;
           position: relative;
-          padding-left: 8px;
-          &:active {
-            opacity: .75;
-          }
-          p {
-            display: inline-block;
-            position: relative;
-            float: right;
-            margin: 1em 0em 1em 1em;
-            font-family: @font-context;
-            font-size: @small-font;
-            font-weight: 400;
-          }
+          float: right;
+          margin: 1em 0em 1em 1em;
+          font-family: @font-context;
+          font-size: @small-font;
+          font-weight: 400;
         }
       }
     }
@@ -661,119 +654,110 @@ body {
       }
     }
   }
-  .trail-and-trailhead-data {
-    -webkit-transform: translate3d(0, 0, 0);
-    position: absolute;
-    top: 45px; /* green nav bar, plus hardware padding, plus border */
-    bottom: 0;
-    right: 0;
-    left: 0;
-    display: inline-block;
-    background-color: @white-color;
-    overflow: auto;
+  #trail-and-trailhead-data {
+    padding: 0 20px;
+    height: 100%;
+    padding-bottom: @footer-height+@header-height;
+    box-sizing: border-box;
+    background: @white-color;
+    overflow: scroll;
     -webkit-overflow-scrolling: touch;
-    -webkit-transform: translate3d(0, 0, 0);
-    .trail-data {
+
+    #trail-data-header {
       display: inline-block;
       position: relative;
-      height: auto;
-      width: 100%;
-      background-color: @white-color;
-      .trail-attributes {
-        display: inline-block;
+      vertical-align: middle;
+      width: auto;
+      margin: 0;
+      .trail-title {
         position: relative;
-        vertical-align: middle;
+        display: inline-block;
+        min-width: 75%;
+        line-height: 1.2em;
+        font-family: @font-display;
+        font-size: @large-font;
+        margin: 10px 20px 0 20px;
+      }
+      .trail-attribute-distance {
         width: auto;
-        margin: 0;
-        .trail-title {
-          position: relative;
-          display: inline-block;
-          min-width: 75%;
-          line-height: 1.2em;
-          font-family: @font-display;
-          font-size: @large-font;
-          margin: 10px 20px 0 20px;
-        }
-        .trail-attribute-distance {
-          width: auto;
-          vertical-align: top;
-          padding-top: 10px;
-          font-family: @font-context;
-          font-size: @small-font;
-          display: inline-block;
-          position: relative;
-          margin-top: 0;
-          margin-left: 20px;
-          margin-right: 20px;
-          margin-bottom: 10px;
-          font-weight: 400;
-        }
-        .trail-attribute-length {
-          width: auto;
-          vertical-align: top;
-          padding-top: 10px;
-          font-family: @font-context;
-          font-size: @small-font;
-          display: inline-block;
-          position: relative;
-          float: right;
-          text-align: right;
-          margin-top: 0;
-          margin-right: 20px;
-          margin-bottom: 10px;
-          font-weight: 400;
-        }
-      }
-      .trailhead-title-field {
-        display: block;
-        position: relative;
-        height: 1em;
-        margin: 0 20px;
-        .trailhead-icon {
-          display: inline-block;
-          position: relative;
-          float: left;
-          width: auto;
-          margin: .5em 0;
-        }
-        .trailhead-title {
-          position: relative;
-          display: inline-block;
-          font-family: @font-display;
-          font-size: @small-font;
-          float: left;
-          width: auto;
-          max-width: 50%;
-          margin: .5em 10px;
-          font-weight: 700;
-        }
-        .trailhead-address {
-          display: inline-block;
-          position: relative;
-          float: right;
-          width: auto;
-          margin: .5em 0 1em 0;
-          font-family: @font-context;
-          font-size: @small-font;
-          padding: 6px;
-          background-color: @blue-color;
-          border-radius: 2px;
-          color: @white-color;
-          text-decoration: none;
-        }
-      }
-      .photo-box {
+        vertical-align: top;
+        padding-top: 10px;
+        font-family: @font-context;
+        font-size: @small-font;
         display: inline-block;
         position: relative;
-        width: 100%;
-        img {
-          height: auto;
-          max-width: 100%;
-        }
+        margin-top: 0;
+        margin-left: 20px;
+        margin-right: 20px;
+        margin-bottom: 10px;
+        font-weight: 400;
       }
+      .trail-attribute-length {
+        width: auto;
+        vertical-align: top;
+        padding-top: 10px;
+        font-family: @font-context;
+        font-size: @small-font;
+        display: inline-block;
+        position: relative;
+        float: right;
+        text-align: right;
+        margin-top: 0;
+        margin-right: 20px;
+        margin-bottom: 10px;
+        font-weight: 400;
+      }
+    }
+    .trailhead-title-field {
+      display: block;
+      position: relative;
+      height: 1em;
+      margin: 0 20px;
+      .trailhead-icon {
+        display: inline-block;
+        position: relative;
+        float: left;
+        width: auto;
+        margin: .5em 0;
+      }
+      .trailhead-title {
+        position: relative;
+        display: inline-block;
+        font-family: @font-display;
+        font-size: @small-font;
+        float: left;
+        width: auto;
+        max-width: 50%;
+        margin: .5em 10px;
+        font-weight: 700;
+      }
+      .trailhead-address {
+        display: inline-block;
+        position: relative;
+        float: right;
+        width: auto;
+        margin: .5em 0 1em 0;
+        font-family: @font-context;
+        font-size: @small-font;
+        padding: 6px;
+        background-color: @blue-color;
+        border-radius: 2px;
+        color: @white-color;
+        text-decoration: none;
+      }
+    }
+    .photo-box {
+      margin-left: -20px;
+      margin-right: -20px;
+      img {
+        height: auto;
+        max-width: 100%;
+      }
+    }
+    .trailhead-data {
+      padding-top: 10px;
+
       .trail-subhead {
-        display: inline-block;
-        position: relative;
         width: 100%;
         font-family: @font-context;
         font-size: 12px;
@@ -829,16 +813,6 @@ body {
         line-height: 1.4em;
         font-weight: 400;
       }
-    }
-    .trailhead-data {
-      -webkit-transform: translate3d(0, 0, 0);
-      display: inline-block;
-      position: relative;
-      height: auto;
-      padding-left: 20px;
-      padding-right: 20px;
-      padding-top: 10px;
-      background-color: @white-color;
       .trail-body {
         font-family: @font-display, serif;
         font-size: @small-font;


### PR DESCRIPTION
- Changes how trail details animates by utilizing the `top` property
  and `calc()` notation to reduce the number of variables in the
  setTrailViewOffset() method.
- Performs CSS cleanup around trail details elements by removing unnecessary properties.
- Performs HTML cleanup by removing unneeded nesting and assigning IDs
  to elements that are retrieved by JS.
- Migrates some HTML elements around the trail details to semantic
  elements so the nesting of elements is easier to see in the source HTML.
- Adds methods to controller for toggling trail details, and
  consolidates code around toggling the trail details. Also, creates
  variables for DOM elements that were looked up repeatedly.

Of note, the trail details page is no longer hidden with ng-show; it’s
simply moved out of view. This is to accommodate animating it out of
view when the view changes to the map view. It’s at a 3000 z-index, so
anything that should appear on top of it should be greater than
z-index:3000.
