### PR TITLE
Fixes #139 - positions search area

### DIFF
--- a/www/css/application.css
+++ b/www/css/application.css
@@ -35,6 +35,8 @@ body {
   weight: 300;
   overflow-y: hidden;
   z-index: 3000;
+  padding: 0 20px;
+  box-sizing: border-box;
 }
 #content {
   position: fixed;
@@ -218,7 +220,7 @@ body {
 }
 /* SEARCH VIEW */
 #search-view #header {
-  height: 140px;
+  height: 141px;
   background-color: #f6f6f6;
   color: #242424;
   border-bottom: 1px solid #242424;
@@ -226,7 +228,6 @@ body {
 #search-view #header .search-form {
   width: 100%;
   height: auto;
-  padding: 0px 20px;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
 }
@@ -249,6 +250,7 @@ body {
   position: absolute;
 }
 #search-view #header .search-form .search-input-container .search-input {
+  -webkit-appearance: none;
   border-radius: 3px;
   width: 100%;
   color: #242424;
@@ -266,8 +268,7 @@ body {
   font-size: 24px;
 }
 #search-view #header .filter-info {
-  margin: 0px 0 10px 20px;
-  width: 100%;
+  margin: 0 0 10px;
   height: 1em;
   font-family: 'Source Sans Pro', sans-serif;
   font-size: 12px;
@@ -275,14 +276,14 @@ body {
 }
 #search-view #header .trail-icons {
   width: 100%;
-  text-align: justify;
+  display: -webkit-flex;
+  -webkit-justify-content: space-between;
 }
 #search-view #header .trail-icons .icon-box {
   display: inline-block;
   text-align: center;
   width: 50px;
   height: 50px;
-  margin: 0 0 0 20px;
   background-color: #ffffff;
   border-radius: 2px;
   border: 1px solid #a3a3a3;
@@ -291,9 +292,6 @@ body {
   text-align: center;
   height: 60%;
   margin-top: 20%;
-}
-#search-view #header .trail-icons .first-filter {
-  margin: 0 0 0 20px;
 }
 #search-view #header .trail-icons .trail-icons:after {
   content: "";

--- a/www/index.html
+++ b/www/index.html
@@ -213,7 +213,7 @@
             <span ng-hide="searchFilter.canFoot">Show Trails for All Activities</span>
           </div>
           <div class="trail-icons">
-            <div class="icon-box first-filter" ng-click="setSearchFilter('canFoot')">
+            <div class="icon-box" ng-click="setSearchFilter('canFoot')">
               <img class="icon" src="img/foot-gray.png" ng-show="searchFilters.isFiltered('canFoot')" ng-cloak>
               <img class="icon" src="img/foot-light-gray.png" ng-hide="searchFilters.isFiltered('canFoot')" ng-cloak>
             </div>

--- a/www/less/application.less
+++ b/www/less/application.less
@@ -74,6 +74,8 @@ body {
   weight: 300;
   overflow-y: hidden;
   z-index: @z-index-3;
+  padding: 0 20px;
+  box-sizing: border-box;
 }
 
 #content {
@@ -303,7 +305,7 @@ body {
 /* SEARCH VIEW */
 #search-view {
   #header {
-    height: 140px;
+    height: 141px;
     background-color: @white-color;
     color: @gray-color;
     border-bottom: 1px solid @gray-color;
@@ -311,7 +313,6 @@ body {
     .search-form {
       width: 100%;
       height: auto;
-      padding: 0px 20px;
       -webkit-box-sizing: border-box;
       box-sizing: border-box;
 
@@ -334,6 +335,7 @@ body {
           position: absolute;
         }
         .search-input {
+          -webkit-appearance: none;
           border-radius: 3px;
           width: 100%;
           color: @gray-color;
@@ -353,8 +355,7 @@ body {
       }
     }
     .filter-info {
-      margin: 0px 0 10px 20px;
-      width: 100%;
+      margin: 0 0 10px;
       height: 1em;
       font-family: @font-context;
       font-size: @small-font;
@@ -362,13 +363,13 @@ body {
     }
     .trail-icons {
       width: 100%;
-      text-align: justify;
+      display: -webkit-flex;
+      -webkit-justify-content: space-between;
       .icon-box {
         display: inline-block;
         text-align: center;
         width: 50px;
         height: 50px;
-        margin: 0 0 0 20px;
         background-color: #ffffff;
         border-radius: 2px;
         border: 1px solid @light-gray-color;
@@ -377,9 +378,6 @@ body {
           height: 60%;
           margin-top: 20%;
         }
-      }
-      .first-filter {
-        margin: 0 0 0 20px;
       }
       .trail-icons:after {
         content: "";
@@ -733,7 +731,7 @@ body {
       .trail-icons {
         width: auto;
         display: inline-block;
-        position: relative;;
+        position: relative;
         text-align: justify;
         margin: 10px 0;
         .icon-box {


### PR DESCRIPTION
Search area could be moved to the right. This commit updates the styles
to:
- provide even padding around all search elements.
- evenly distribute the filters
- increase height of header by 1px to remove 1px gap between search
  header and content.
